### PR TITLE
Move delegated identity to id_token from access_token, compatibility with spacetimedb

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,21 +17,25 @@ APPLE_KEY_ID=
 # Apple Auth Key PEM
 APPLE_AUTH_KEY_PEM=
 
-# OAuth Login redirect URL
-OAUTH_REDIRECT_URL=http://127.0.0.1:3000/oauth_callback
+# Server URL
+# "/" at the end is optional
+SERVER_URL=http://127.0.0.1:3000/
 
-# JWT ED25519 Private Key PEM
-# generated using `openssl genpkey -algorithm ed25519 -out jwt_ed.pem`
+# JWT ES256 Private Key PEM
+# generated using  `openssl ecparam -genkey -noout -name prime256v1 | openssl pkcs8 -topk8 -nocrypt -out jwt_es256.pem`
 # Do not use the example value in production, generate your own
-JWT_ED_PEM="-----BEGIN PRIVATE KEY-----
-MC4CAQAwBQYDK2VwBCIEIF7hq2r9TEJF4YIHEeB+NiSkKZZSERtbrLL+7gRkdiTb
+JWT_EC_PEM="-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgHBYSV3VZE2tICdhH
+3OVtyeto9Do/9RwesTqOInUVXDqhRANCAARk4mYQeAYAJL/9ynQSOKvnrJeoUJRp
+LeVz4FG0j8JDL5GKGZsFSDWO+cPzd3wKdLcwIhFjbihpcPV90uFqc55m
 -----END PRIVATE KEY-----"
 
-# JWT ED25519 Public Key PEM
-# generated using `openssl pkey -in jwt_ed.pem -pubout -out jwt_pub_ed.pem`
+# JWT ES256 Public Key PEM
+# generated using `openssl ec -in jwt_es256.pem -pubout -out jwt_pub_es256.pem`
 # Do not use the example value in production, generate your own
-JWT_PUB_ED_PEM="-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEAxNfNUuwb7mAcV2KyEOcOJun1YMwNO5/IJmpVnFGcLUc=
+JWT_PUB_EC_PEM="-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZOJmEHgGACS//cp0Ejir56yXqFCU
+aS3lc+BRtI/CQy+RihmbBUg1jvnD83d8CnS3MCIRY24oaXD1fdLhanOeZg==
 -----END PUBLIC KEY-----"
 
 # JWT ED25519 Private key for generating Client secrets

--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -32,7 +32,7 @@ jobs:
           flyctl secrets set COOKIE_KEY="$COOKIE_KEY" --app "yral-auth-v2" --stage
           flyctl secrets set REDIS_URL="$REDIS_URL" --app "yral-auth-v2" --stage
           flyctl secrets set GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET --app "yral-auth-v2" --stage
-          flyctl secrets set JWT_ED_PEM="$JWT_ED_PEM" --app "yral-auth-v2" --stage
+          flyctl secrets set JWT_EC_PEM="$JWT_EC_PEM" --app "yral-auth-v2" --stage
           flyctl secrets set CLIENT_JWT_ED_PEM="$CLIENT_JWT_ED_PEM" --app "yral-auth-v2" --stage
           flyctl secrets set APPLE_AUTH_KEY_PEM="$APPLE_AUTH_KEY_PEM" --app "yral-auth-v2" --stage
         env:
@@ -40,7 +40,7 @@ jobs:
           COOKIE_KEY: ${{ secrets.AUTH_SESSION_COOKIE_SIGNING_SECRET_KEY }}
           REDIS_URL: ${{ secrets.AUTH_FLY_IO_UPSTASH_REDIS_DATABASE_CONNECTION_STRING }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_SIGNING_OAUTH_CLIENT_CREDENTIAL_CLIENT_SECRET }}
-          JWT_ED_PEM: ${{ secrets.AUTH_JWT_ED_PEM }}
+          JWT_EC_PEM: ${{ secrets.AUTH_JWT_ES256_SIGNING_SECRET_KEY_PEM }}
           CLIENT_JWT_ED_PEM: ${{ secrets.CLIENT_JWT_ED_PEM }}
           APPLE_AUTH_KEY_PEM: ${{ secrets.APPLE_AUTH_KEY_PEM }}
       - name: Deploy a docker container to Fly.io

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ hex = { version = "0.4.3", optional = true}
 log = "0.4.27"
 simple_logger = { version = "4.0", optional = true }
 dotenvy = { version = "0.15.7", optional = true }
-jsonwebtoken = { version = "9.3.1", optional = true }
+jsonwebtoken = { version = "9.3.1" }
 candid = { version = "0.10.13" }
 serde_json = { version = "1.0.140" }
 redis = { version = "0.25.2", features = [
@@ -55,6 +55,7 @@ ic-agent = { version = "0.38.1", default-features = false }
 rand = { version = "0.8.5", optional = true }
 web-time = "1.1.0"
 yral-identity = { git = "https://github.com/yral-dapp/yral-identity.git", rev = "adbf4be5cb62a26f2a90032261321bf1df33f08b", default-features = false }
+p256 = { version = "0.13.2", features = ["pkcs8"], optional = true }
 
 [features]
 redis-kv = []
@@ -76,7 +77,6 @@ ssr = [
     "dep:hex",
     "dep:simple_logger",
     "dep:dotenvy",
-    "dep:jsonwebtoken",
     "dep:bb8",
     "dep:bb8-redis",
     "dep:redb",
@@ -85,6 +85,7 @@ ssr = [
     "dep:k256",
     "dep:rand",
     "yral-identity/ic-git",
+    "dep:p256"
 ]
 release-lib = ["hydrate"]
 release-bin = ["ssr", "redis-kv"]

--- a/fly.toml
+++ b/fly.toml
@@ -11,8 +11,9 @@ primary_region = 'sin'
 [env]
   PORT = '8080'
   GOOGLE_CLIENT_ID = '804814798298-taifmq3k6olk9bjr1cqb9gfnp1mssqqb.apps.googleusercontent.com'
-  JWT_PUB_ED_PEM = """-----BEGIN PUBLIC KEY-----
-MCowBQYDK2VwAyEA04mJta0mU/O+rAVAjNzJxEWp+U8GKksjEI+vbepDfsQ=
+  JWT_PUB_EC_PEM="""-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoqN3/0RNfrnrnYGxKBgy/qHnmITr
++6ucjxStx7tjA30QJZlWzo0atxmY8y9dUR+eKQI0SnbQds4xLEU8+JGm8Q==
 -----END PUBLIC KEY-----"""
   SERVER_URL = "https://auth.yral.com/"
   APPLE_CLIENT_ID = "com.yral.yral-auth"

--- a/fly.toml
+++ b/fly.toml
@@ -14,7 +14,7 @@ primary_region = 'sin'
   JWT_PUB_ED_PEM = """-----BEGIN PUBLIC KEY-----
 MCowBQYDK2VwAyEA04mJta0mU/O+rAVAjNzJxEWp+U8GKksjEI+vbepDfsQ=
 -----END PUBLIC KEY-----"""
-  OAUTH_REDIRECT_URL = "https://auth.yral.com/oauth_callback"
+  SERVER_URL = "https://auth.yral.com/"
   APPLE_CLIENT_ID = "com.yral.yral-auth"
   APPLE_TEAM_ID = "2UL556KNXC"
   APPLE_KEY_ID = "9DWVYWDYD8"

--- a/src/api/server_impl.rs
+++ b/src/api/server_impl.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use axum::{
-    http::HeaderMap,
     response::{IntoResponse, Response},
     Extension, Form, Json,
 };
@@ -24,7 +23,8 @@ use crate::{
             generate::{generate_access_token_and_id_token_jwt, generate_refresh_token_jwt},
             AuthCodeClaims, RefreshTokenClaims,
         },
-        AuthGrantQuery, TokenGrantError, TokenGrantErrorKind, TokenGrantRes, TokenGrantResult,
+        AuthGrantQuery, PartialOIDCConfig, TokenGrantError, TokenGrantErrorKind, TokenGrantRes,
+        TokenGrantResult,
     },
     utils::{identity::generate_random_identity_and_save, time::current_epoch},
 };
@@ -65,12 +65,20 @@ impl IntoResponse for TokenGrantResult {
     }
 }
 
+pub async fn handle_well_known_jwks(Extension(ctx): Extension<Arc<ServerCtx>>) -> Response {
+    Json(ctx.jwk_pairs.well_known_jwks.clone()).into_response()
+}
+
+pub async fn handle_oidc_configuration(Extension(ctx): Extension<Arc<ServerCtx>>) -> Response {
+    let jwks_uri = format!("{}/.well-known/jwks.json", ctx.server_url,);
+
+    Json(PartialOIDCConfig { jwks_uri }).into_response()
+}
+
 pub async fn handle_oauth_token_grant(
-    headers: HeaderMap,
     Extension(ctx): Extension<Arc<ServerCtx>>,
     Form(req): Form<AuthGrantQuery>,
 ) -> Response {
-    let host = headers.get("host").unwrap().to_str().unwrap();
     let res = match req {
         AuthGrantQuery::AuthorizationCode {
             code,
@@ -81,7 +89,6 @@ pub async fn handle_oauth_token_grant(
         } => {
             handle_authorization_code_grant(
                 &ctx,
-                host,
                 code,
                 redirect_uri,
                 code_verifier,
@@ -94,11 +101,11 @@ pub async fn handle_oauth_token_grant(
             refresh_token,
             client_id,
             client_secret,
-        } => handle_refresh_token_grant(&ctx, host, refresh_token, client_id, client_secret).await,
+        } => handle_refresh_token_grant(&ctx, refresh_token, client_id, client_secret).await,
         AuthGrantQuery::ClientCredentials {
             client_id,
             client_secret,
-        } => handle_client_credentials_grant(&ctx, host, client_id, client_secret).await,
+        } => handle_client_credentials_grant(&ctx, client_id, client_secret).await,
     };
 
     match res {
@@ -141,7 +148,6 @@ fn delegate_identity(from: &impl Identity) -> DelegatedIdentityWire {
 
 fn generate_access_token_with_identity(
     ctx: &ServerCtx,
-    host: &str,
     identity: Secp256k1Identity,
     client_id: &str,
     nonce: Option<String>,
@@ -154,7 +160,7 @@ fn generate_access_token_with_identity(
         &ctx.jwk_pairs.auth_tokens.encoding_key,
         user_principal,
         delegated_identity,
-        host,
+        &ctx.server_url,
         client_id,
         nonce.clone(),
         is_anonymous,
@@ -162,7 +168,7 @@ fn generate_access_token_with_identity(
     let refresh_token = generate_refresh_token_jwt(
         &ctx.jwk_pairs.auth_tokens.encoding_key,
         user_principal,
-        host,
+        &ctx.server_url,
         client_id,
         nonce,
         is_anonymous,
@@ -173,7 +179,6 @@ fn generate_access_token_with_identity(
 
 async fn generate_access_token(
     ctx: &ServerCtx,
-    host: &str,
     user_principal: Principal,
     client_id: &str,
     nonce: Option<String>,
@@ -198,14 +203,13 @@ async fn generate_access_token(
     })?;
     let id = Secp256k1Identity::from_private_key(sk);
 
-    let grant = generate_access_token_with_identity(ctx, host, id, client_id, nonce, is_anonymous);
+    let grant = generate_access_token_with_identity(ctx, id, client_id, nonce, is_anonymous);
 
     Ok(grant)
 }
 
 async fn handle_authorization_code_grant(
     ctx: &ServerCtx,
-    host: &str,
     code: String,
     redirect_uri: Url,
     code_verifier: String,
@@ -216,7 +220,7 @@ async fn handle_authorization_code_grant(
 
     let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
     validation.set_audience(&[&client_id]);
-    validation.set_issuer(&[host]);
+    validation.set_issuer(&[&ctx.server_url]);
 
     let auth_code = jsonwebtoken::decode::<AuthCodeClaims>(
         &code,
@@ -248,7 +252,6 @@ async fn handle_authorization_code_grant(
 
     let grant = generate_access_token(
         ctx,
-        host,
         code_claims.sub,
         &client_id,
         code_claims.nonce.clone(),
@@ -261,7 +264,6 @@ async fn handle_authorization_code_grant(
 
 async fn handle_refresh_token_grant(
     ctx: &ServerCtx,
-    host: &str,
     refresh_token: String,
     client_id: String,
     client_secret: Option<String>,
@@ -270,7 +272,7 @@ async fn handle_refresh_token_grant(
 
     let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
     validation.set_audience(&[&client_id]);
-    validation.set_issuer(&[host]);
+    validation.set_issuer(&[&ctx.server_url]);
 
     let refresh_token = jsonwebtoken::decode::<RefreshTokenClaims>(
         &refresh_token,
@@ -286,7 +288,6 @@ async fn handle_refresh_token_grant(
 
     let grant = generate_access_token(
         ctx,
-        host,
         refresh_claims.sub,
         &client_id,
         None,
@@ -299,7 +300,6 @@ async fn handle_refresh_token_grant(
 
 async fn handle_client_credentials_grant(
     ctx: &ServerCtx,
-    host: &str,
     client_id: String,
     client_secret: Option<String>,
 ) -> Result<TokenGrantRes, TokenGrantError> {
@@ -312,7 +312,7 @@ async fn handle_client_credentials_grant(
             error_description: e.to_string(),
         })?;
 
-    let grant = generate_access_token_with_identity(ctx, host, identity, &client_id, None, true);
+    let grant = generate_access_token_with_identity(ctx, identity, &client_id, None, true);
 
     Ok(grant)
 }

--- a/src/api/server_impl.rs
+++ b/src/api/server_impl.rs
@@ -21,7 +21,7 @@ use crate::{
     oauth::{
         client_validation::ClientIdValidator,
         jwt::{
-            generate::{generate_access_token_jwt, generate_refresh_token_jwt},
+            generate::{generate_access_token_and_id_token_jwt, generate_refresh_token_jwt},
             AuthCodeClaims, RefreshTokenClaims,
         },
         AuthGrantQuery, TokenGrantError, TokenGrantErrorKind, TokenGrantRes, TokenGrantResult,
@@ -150,7 +150,7 @@ fn generate_access_token_with_identity(
     let delegated_identity = delegate_identity(&identity);
     let user_principal = identity.sender().unwrap();
 
-    let access_token = generate_access_token_jwt(
+    let (access_token, id_token) = generate_access_token_and_id_token_jwt(
         &ctx.jwk_pairs.auth_tokens.encoding_key,
         user_principal,
         delegated_identity,
@@ -168,7 +168,7 @@ fn generate_access_token_with_identity(
         is_anonymous,
     );
 
-    TokenGrantRes::new(access_token, refresh_token)
+    TokenGrantRes::new(access_token, id_token, refresh_token)
 }
 
 async fn generate_access_token(

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -10,3 +10,5 @@ pub const APPLE_ISSUER_URL: &str = "https://appleid.apple.com";
 pub const ACCESS_TOKEN_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 7);
 /// Refresh expiry, 30 days
 pub const REFRESH_TOKEN_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 30);
+
+pub const AUTH_TOKEN_KID: &str = "default";

--- a/src/context/server.rs
+++ b/src/context/server.rs
@@ -83,7 +83,7 @@ impl Default for JwkPairs {
         let auth_jwt_decoding_jwk = Jwk {
             common: jwk::CommonParameters {
                 public_key_use: Some(jwk::PublicKeyUse::Signature),
-                key_algorithm: Some(jwk::KeyAlgorithm::EdDSA),
+                key_algorithm: Some(jwk::KeyAlgorithm::ES256),
                 key_id: Some(AUTH_TOKEN_KID.into()),
                 ..Default::default()
             },

--- a/src/context/server.rs
+++ b/src/context/server.rs
@@ -1,17 +1,22 @@
 use std::{collections::HashMap, env, sync::Arc};
 
 use axum::extract::FromRef;
+use base64::{prelude::BASE64_URL_SAFE_NO_PAD, Engine};
+use jsonwebtoken::jwk::{self, Jwk};
 use leptos::{config::LeptosOptions, prelude::expect_context};
 use leptos_axum::AxumRouteListing;
 use openidconnect::{
     core::{CoreClient, CoreProviderMetadata},
     reqwest, ClientId, ClientSecret, IssuerUrl, RedirectUrl,
 };
+use p256::pkcs8::DecodePublicKey;
 
 use crate::{
-    consts::{APPLE_ISSUER_URL, GOOGLE_ISSUER_URL},
+    consts::{APPLE_ISSUER_URL, AUTH_TOKEN_KID, GOOGLE_ISSUER_URL},
     kv::KVStoreImpl,
-    oauth::{client_validation::ClientIdValidatorImpl, SupportedOAuthProviders},
+    oauth::{
+        client_validation::ClientIdValidatorImpl, jwt::JsonWebKeySet, SupportedOAuthProviders,
+    },
     oauth_provider::{
         AppleOAuthProvider, IdentityOAuthProvider, OAuthProviderImpl, StdOAuthClient,
     },
@@ -30,14 +35,18 @@ pub struct JwkPair {
 }
 
 impl JwkPair {
-    pub fn load_from_env(encoding_env: &str, decoding_env: &str) -> Self {
+    fn load_encoding_key_from_env(encoding_env: &str) -> jsonwebtoken::EncodingKey {
         let jwt_pem =
             env::var(encoding_env).unwrap_or_else(|_| panic!("`{encoding_env}` is required!"));
+        jsonwebtoken::EncodingKey::from_ed_pem(jwt_pem.as_bytes())
+            .unwrap_or_else(|_| panic!("invalid `{encoding_env}`"))
+    }
+
+    pub fn load_from_env(encoding_env: &str, decoding_env: &str) -> Self {
+        let encoding_key = Self::load_encoding_key_from_env(encoding_env);
+
         let jwt_pub_pem =
             env::var(decoding_env).unwrap_or_else(|_| panic!("`{decoding_env}` is required!"));
-
-        let encoding_key = jsonwebtoken::EncodingKey::from_ed_pem(jwt_pem.as_bytes())
-            .unwrap_or_else(|_| panic!("invalid `{encoding_env}`"));
         let decoding_key = jsonwebtoken::DecodingKey::from_ed_pem(jwt_pub_pem.as_bytes())
             .unwrap_or_else(|_| panic!("invalid `{decoding_env}`"));
 
@@ -51,19 +60,61 @@ impl JwkPair {
 pub struct JwkPairs {
     pub auth_tokens: JwkPair,
     pub client_tokens: JwkPair,
+    pub well_known_jwks: JsonWebKeySet,
 }
 
 impl Default for JwkPairs {
     fn default() -> Self {
+        let auth_jwt_pub_pem =
+            env::var("JWT_PUB_EC_PEM").unwrap_or_else(|_| panic!("`JWT_PUB_EC_PEM` is required!"));
+        let auth_jwt_ec_pub = p256::ecdsa::VerifyingKey::from_public_key_pem(&auth_jwt_pub_pem)
+            .expect("Invalid `JWT_PUB_ED_PEM`");
+        let auth_jwt_ec = auth_jwt_ec_pub.to_encoded_point(false);
+
+        let auth_jwt_x = auth_jwt_ec.x().unwrap();
+        let auth_jwt_x_b64 = BASE64_URL_SAFE_NO_PAD.encode(auth_jwt_x);
+        let auth_jwt_y = auth_jwt_ec.y().unwrap();
+        let auth_jwt_y_b64 = BASE64_URL_SAFE_NO_PAD.encode(auth_jwt_y);
+
+        let auth_jwt_decoding_key =
+            jsonwebtoken::DecodingKey::from_ec_components(&auth_jwt_x_b64, &auth_jwt_y_b64)
+                .unwrap();
+
+        let auth_jwt_decoding_jwk = Jwk {
+            common: jwk::CommonParameters {
+                public_key_use: Some(jwk::PublicKeyUse::Signature),
+                key_algorithm: Some(jwk::KeyAlgorithm::EdDSA),
+                key_id: Some(AUTH_TOKEN_KID.into()),
+                ..Default::default()
+            },
+            algorithm: jwk::AlgorithmParameters::EllipticCurve(jwk::EllipticCurveKeyParameters {
+                key_type: jwk::EllipticCurveKeyType::EC,
+                curve: jwk::EllipticCurve::P256,
+                x: auth_jwt_x_b64,
+                y: auth_jwt_y_b64,
+            }),
+        };
+
+        let auth_jwt_pem =
+            env::var("JWT_EC_PEM").unwrap_or_else(|_| panic!("`JWT_EC_PEM` is required!"));
+
         Self {
-            auth_tokens: JwkPair::load_from_env("JWT_ED_PEM", "JWT_PUB_ED_PEM"),
+            auth_tokens: JwkPair {
+                encoding_key: jsonwebtoken::EncodingKey::from_ec_pem(auth_jwt_pem.as_bytes())
+                    .expect("invalid `JWT_EC_PEM`"),
+                decoding_key: auth_jwt_decoding_key,
+            },
             client_tokens: JwkPair::load_from_env("CLIENT_JWT_ED_PEM", "CLIENT_JWT_PUB_ED_PEM"),
+            well_known_jwks: JsonWebKeySet {
+                keys: vec![auth_jwt_decoding_jwk],
+            },
         }
     }
 }
 
 pub struct ServerCtx {
     pub oauth_http_client: reqwest::Client,
+    pub server_url: String,
     pub oauth_providers: HashMap<SupportedOAuthProviders, OAuthProviderImpl>,
     pub cookie_key: axum_extra::extract::cookie::Key,
     pub jwk_pairs: JwkPairs,
@@ -92,12 +143,12 @@ impl ServerCtx {
 
     async fn init_oauth_providers(
         http_client: &reqwest::Client,
+        server_url: &str,
     ) -> HashMap<SupportedOAuthProviders, OAuthProviderImpl> {
         let mut oauth_providers = HashMap::new();
 
-        let redirect_uri =
-            env::var("OAUTH_REDIRECT_URL").expect("`OAUTH_REDIRECT_URI` is required!");
-        let redirect_uri = RedirectUrl::new(redirect_uri).expect("Invalid `OAUTH_REDIRECT_URI`");
+        let redirect_uri = format!("{server_url}/oauth_callback");
+        let redirect_uri = RedirectUrl::new(redirect_uri).expect("Invalid `SERVER_URL`");
 
         // Google OAuth
         let google_client_secret =
@@ -168,7 +219,14 @@ impl ServerCtx {
             .redirect(reqwest::redirect::Policy::none())
             .build()
             .expect("Client should build");
-        let oauth_providers = Self::init_oauth_providers(&oauth_http_client).await;
+
+        let server_url = env::var("SERVER_URL").expect("`SERVER_URL` is required");
+        let server_url = server_url
+            .strip_suffix("/")
+            .unwrap_or(&server_url)
+            .to_string();
+
+        let oauth_providers = Self::init_oauth_providers(&oauth_http_client, &server_url).await;
 
         let cookie_key = Self::init_cookie_key();
 
@@ -177,6 +235,7 @@ impl ServerCtx {
         Self {
             oauth_http_client,
             oauth_providers,
+            server_url,
             cookie_key,
             jwk_pairs: JwkPairs::default(),
             kv_store,

--- a/src/oauth/jwt/mod.rs
+++ b/src/oauth/jwt/mod.rs
@@ -1,4 +1,5 @@
 use candid::Principal;
+use jsonwebtoken::jwk::Jwk;
 use serde::{Deserialize, Serialize};
 use url::Url;
 use yral_types::delegated_identity::DelegatedIdentityWire;
@@ -65,4 +66,9 @@ pub struct ClientSecretClaims {
     pub iat: usize,
     pub iss: String,
     pub sub: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct JsonWebKeySet {
+    pub keys: Vec<Jwk>,
 }

--- a/src/oauth/jwt/mod.rs
+++ b/src/oauth/jwt/mod.rs
@@ -22,7 +22,19 @@ pub struct AuthCodeClaims {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AuthTokenClaims {
+pub struct AccessTokenClaims {
+    aud: String,
+    exp: usize,
+    iat: usize,
+    iss: String,
+    sub: Principal,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<String>,
+    ext_is_anonymous: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdTokenClaims {
     aud: String,
     exp: usize,
     iat: usize,

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -299,3 +299,8 @@ pub enum TokenGrantResult {
     Ok(TokenGrantRes),
     Err(TokenGrantError),
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PartialOIDCConfig {
+    pub jwks_uri: String,
+}

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -274,6 +274,7 @@ pub enum TokenType {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenGrantRes {
     pub access_token: String,
+    pub id_token: String,
     pub token_type: TokenType,
     // seconds
     pub expires_in: usize,
@@ -281,9 +282,10 @@ pub struct TokenGrantRes {
 }
 
 impl TokenGrantRes {
-    pub fn new(access_token: String, refresh_token: String) -> Self {
+    pub fn new(access_token: String, id_token: String, refresh_token: String) -> Self {
         Self {
             access_token,
+            id_token,
             token_type: TokenType::Bearer,
             expires_in: ACCESS_TOKEN_MAX_AGE.as_secs() as usize,
             refresh_token,


### PR DESCRIPTION
implements https://github.com/dolr-ai/product-roadmap/issues/461

The `ext_delegated_identity` claim has been moved to the more appropriate "id_token" in the token grant flow. Now we can safely use access_token wherever we want, without worrying about delegated identity leakage

The following changes were made for spacetimedb:

Added barebones implementation for `/.well-known/openid-configuration` --> This does not completely implement the openid spec, and has the bare minimum so that spacetimedb could lookup key details

Added implementation for `/.well-known/jwks.json` --> spacetimedb will hit this endpoint after looking it up from `/.well-known/openid-configuration`

Switched from Ed25519 to ES256 for auth token JWTs. spacetimedb does not support ed25519

All consumers have been notified that there will be changes to the API.

@saikat-das-yral must also add new secret for ES256 in the repository and provide me with the public key before we merge